### PR TITLE
add gdb for windows-toolchain

### DIFF
--- a/toolchain/cygwin64/install-cygwin-px4.bat
+++ b/toolchain/cygwin64/install-cygwin-px4.bat
@@ -12,7 +12,7 @@ SET LOCALDIR=%TEMP%/cygwin-installation-files
 SET ROOTDIR=%CD%
 
 REM configure packages we will install (in addition to the default packages)
-SET PACKAGES=cmake,gcc-g++,git,make,ninja,patch,xxd,nano,python2,python2-pip,python2-numpy,python2-jinja2,unzip,astyle,bash-completion,wget,libcurl-devel,procps-ng,moreutils
+SET PACKAGES=cmake,gcc-g++,gdb,git,make,ninja,patch,xxd,nano,python2,python2-pip,python2-numpy,python2-jinja2,unzip,astyle,bash-completion,wget,libcurl-devel,procps-ng,moreutils
 
 REM do installation
 ECHO *** Installing Packages


### PR DESCRIPTION
This PR is to solve #7.   After calling this file, gcc 7.4.0 and gdb 8.1.1 is installed in my computer, and gdb works fine in simulation.