### PR TITLE
Component updates for Toolchain 0.6

### DIFF
--- a/toolchain/apache-ant/install-apache-ant.bat
+++ b/toolchain/apache-ant/install-apache-ant.bat
@@ -5,5 +5,5 @@ CD %~dp0
 CALL ..\scripts\setup-environment.bat x
 
 REM install apache-ant in this folder
-CALL bash -c "wget -nv -O apache-ant.zip -nc http://mirror.easyname.ch/apache//ant/binaries/apache-ant-1.10.5-bin.zip && unzip -q apache-ant.zip && rm apache-ant.zip && f=(./*) && mv ./*/* . && rmdir "${f}""
+CALL bash -c "wget -nv -O apache-ant.zip -nc http://www.pirbot.com/mirrors/apache//ant/binaries/apache-ant-1.10.7-bin.zip && unzip -q apache-ant.zip && rm apache-ant.zip && f=(./*) && mv ./*/* . && rmdir "${f}""
 ENDLOCAL

--- a/toolchain/cygwin64/install-cygwin-px4.bat
+++ b/toolchain/cygwin64/install-cygwin-px4.bat
@@ -12,7 +12,7 @@ SET LOCALDIR=%TEMP%/cygwin-installation-files
 SET ROOTDIR=%CD%
 
 REM configure packages we will install (in addition to the default packages)
-SET PACKAGES=cmake,gcc-g++,gdb,git,make,ninja,patch,xxd,nano,python2,python2-pip,python2-numpy,python2-jinja2,unzip,astyle,bash-completion,wget,libcurl-devel,procps-ng,moreutils
+SET PACKAGES=cmake,gcc-g++,gdb,git,make,ninja,patch,xxd,nano,python27,python27-pip,python27-numpy,python27-jinja2,unzip,astyle,bash-completion,wget,libcurl-devel,procps-ng,moreutils
 
 REM do installation
 ECHO *** Installing Packages

--- a/toolchain/gcc-arm/install-gcc-arm.bat
+++ b/toolchain/gcc-arm/install-gcc-arm.bat
@@ -5,6 +5,6 @@ CD %~dp0
 CALL ..\scripts\setup-environment.bat x
 
 REM install gcc-arm in this folder
-CALL bash -c "wget -nv -O gcc-arm.zip -nc https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-win32.zip && unzip -q gcc-arm.zip && rm gcc-arm.zip"
+CALL bash -c "wget -nv -O gcc-arm.zip -nc https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-win32.zip && unzip -q gcc-arm.zip && rm gcc-arm.zip"
 
 ENDLOCAL


### PR DESCRIPTION
Since after including gdb #9 and running the CI to create a new installer failed: https://ci.appveyor.com/project/Dronecode/windows-toolchain/builds/27622684
I fixed the issues and updated ARM GCC to one version later. GCC 8 doesn't successfully compile NuttX at the moment, see https://github.com/PX4/Firmware/issues/11410.