### PR TITLE
Windows 10 + Eclipse CDT

### DIFF
--- a/toolchain/cygwin64/install-cygwin-python-packages.bat
+++ b/toolchain/cygwin64/install-cygwin-python-packages.bat
@@ -5,8 +5,8 @@ CD %~dp0
 CALL ..\scripts\setup-environment.bat x
 
 REM install needed Python 2 packages under cygwin
-CALL bash -c "pip2 -q --disable-pip-version-check install toml pyserial pyulog empy pyyaml cerberus pyros-genmsg"
+CALL bash -c "pip2 -q --disable-pip-version-check install --user toml pyserial pyulog empy pyyaml cerberus pyros-genmsg"
 REM install needed Python 3 packages under cygwin
-CALL bash -c "pip3 -q --disable-pip-version-check install toml pyserial pyulog empy pyyaml cerberus pyros-genmsg"
+CALL bash -c "pip3 -q --disable-pip-version-check install --user toml pyserial pyulog empy pyyaml cerberus pyros-genmsg"
 
 ENDLOCAL

--- a/toolchain/scripts/setup-environment.bat
+++ b/toolchain/scripts/setup-environment.bat
@@ -20,6 +20,12 @@ SET WINDOWS_PATH=%PATH%
 
 REM path to Cygwin Unix Environment
 SET PATH=%PX4_DIR%\toolchain\cygwin64\bin
+REM path to python library
+SET PATH=%PATH%;%PX4_DIR%\toolchain\cygwin64\lib
+REM path to python numpy lib
+SET PATH=%PATH%;%PX4_DIR%\toolchain\cygwin64\lib\lapack
+REM path to GCC for ARM-NONE-EABI
+SET PATH=%PATH%;%PX4_DIR%\toolchain\gcc-arm\arm-none-eabi\bin
 REM path to GCC for ARM Compiler
 SET PATH=%PATH%;%PX4_DIR%\toolchain\gcc-arm\bin
 REM path to Java Developement Kit


### PR DESCRIPTION
@MaEtUgR Thank you for your interest!
The main problem was in Eclipse CDT environment that did not see the python numpy and toml package. In "run-console.bat" environment everything works fine.
After some research, it turned out that:

To correctly determine Python toml package in the Eclipse CDT environment, you need to pip install with the --user attribute.
Eclipse CDT must have the address to \lib\lapack in the %PATH to correctly determine Python numpy package.