### PR TITLE
Fix default python problem

### DIFF
--- a/toolchain/cygwin64/install-cygwin-python-packages.bat
+++ b/toolchain/cygwin64/install-cygwin-python-packages.bat
@@ -4,6 +4,8 @@ ECHO ** Installing Python Packages in Cygwin for PX4 Toolchain
 CD %~dp0
 CALL ..\scripts\setup-environment.bat x
 
+REM create symbolic link to make python3 the default python binary
+CALL bash -c "ln -sf /usr/bin/python3 /usr/local/bin/python"
 REM install needed Python 2 packages under cygwin
 CALL bash -c "pip2 -q --disable-pip-version-check install toml pyserial pyulog empy pyyaml cerberus pyros-genmsg"
 REM install needed Python 3 packages under cygwin


### PR DESCRIPTION
For https://github.com/PX4/Firmware/pull/14401 I had to add a python package to the toolchain which is usually a small thing and quite well automated. I did it and the Windows CI build went further than looking for that python package but failed in different other random nuttx build places which were not the same for `fmu-v5` and `fmu-v2`.

It took me some debugging today to find out what all these random places have in common: they call the `python` binary directly from the path without any cmake discovery or version e.g. `python2` or `python3` specification. Then I checked and it seems the Cygwin developers stopped defaulting to adding a symbolic link to Python 2 and also don't add one to Python 3 at least if you install both versions which I for now still do for backwards compatibility to PX4 stable `v1.9.2`, `v1.10.1`.

So the fix is to add a symbolic link to the default python version you want to use manually which I added to the beginning of the `install-cygwin-python-packages.bat` script. I chose Python 3 because 2 is deprecated and tested that all older PX4 versions that are still C++ compiler options wise compatible again build with that.

It might be possible to remove Python 2 compatibility completely soon.