### PR TITLE
Add virc to configure expected vim functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # ignore all unnecessary files in home
 /home/*
 !home/.bash_profile
+!home/.virc
 
 # ignore most files from cygwin
 /toolchain/cygwin64/*

--- a/home/.virc
+++ b/home/.virc
@@ -1,0 +1,13 @@
+" Setting only a few sane defaults that people expect
+" Inspired by the Arch Linux global vimrc
+"
+" Use :help '<option>' to see the documentation for the given option.
+"
+" Use Vim defaults instead of 100% vi compatibility
+" Avoid side-effects when nocompatible has already been set.
+
+if &compatible
+  set nocompatible
+endif
+
+set backspace=indent,eol,start


### PR DESCRIPTION
like intro text, working arrow keys and backspace

This was reported by @bys1123 including hints to the solution.
See e.g. https://vi.stackexchange.com/questions/2162/why-doesnt-the-backspace-key-work-in-insert-mode