### PR TITLE
Finally switch to ARM GCC 9, new Cygwin, new Ant, new openJDK

### DIFF
--- a/toolchain/apache-ant/install-apache-ant.bat
+++ b/toolchain/apache-ant/install-apache-ant.bat
@@ -5,5 +5,5 @@ CD %~dp0
 CALL ..\scripts\setup-environment.bat x
 
 REM install apache-ant in this folder
-CALL bash -c "wget -nv -O apache-ant.zip -nc https://www-us.apache.org/dist//ant/binaries/apache-ant-1.10.7-bin.zip && unzip -q apache-ant.zip && rm apache-ant.zip && f=(./*) && mv ./*/* . && rmdir "${f}""
+CALL bash -c "wget -nv -O apache-ant.zip -nc https://downloads.apache.org/ant/binaries/apache-ant-1.10.9-bin.zip && unzip -q apache-ant.zip && rm apache-ant.zip && f=(./*) && mv ./*/* . && rmdir "${f}""
 ENDLOCAL

--- a/toolchain/gcc-arm/install-gcc-arm.bat
+++ b/toolchain/gcc-arm/install-gcc-arm.bat
@@ -5,6 +5,6 @@ CD %~dp0
 CALL ..\scripts\setup-environment.bat x
 
 REM install gcc-arm in this folder
-CALL bash -c "wget -nv -O gcc-arm.zip -nc https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-win32.zip && unzip -q gcc-arm.zip && rm gcc-arm.zip"
+CALL bash -c "wget -nv -O gcc-arm.zip -nc https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-win32.zip && unzip -q gcc-arm.zip && rm gcc-arm.zip"
 
 ENDLOCAL

--- a/toolchain/jdk/install-jdk.bat
+++ b/toolchain/jdk/install-jdk.bat
@@ -5,6 +5,6 @@ CD %~dp0
 CALL ..\scripts\setup-environment.bat x
 
 REM install jdk
-CALL bash -c "wget -nv -O jdk.zip -nc https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/jdk1.8.0_152.zip && unzip -q jdk.zip && rm jdk.zip"
+CALL bash -c "wget -nv -O jdk.zip -nc https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_windows-x64_bin.zip && unzip -q jdk.zip && rm jdk.zip && f=(./*) && mv ./*/* . && rmdir "${f}""
 
 ENDLOCAL

--- a/toolchain/scripts/clone-px4-build-sitl.bat
+++ b/toolchain/scripts/clone-px4-build-sitl.bat
@@ -10,5 +10,5 @@ if not exist ".\home\" mkdir home
 cd home
 
 :: start clone PX4 repo, build and run SITL (login shell required because python modules need /usr/local/bin in the PATH!)
-call bash --login -c "git clone --recursive -j8 https://github.com/PX4/Firmware.git ; cd Firmware && make posix"
+call bash --login -c "git clone --recursive -j8 https://github.com/PX4/Firmware.git ; cd Firmware && make px4_sitl"
 popd

--- a/toolchain/scripts/clone-px4-run-sitl.bat
+++ b/toolchain/scripts/clone-px4-run-sitl.bat
@@ -10,5 +10,5 @@ if not exist ".\home\" mkdir home
 cd home
 
 :: start clone PX4 repo, build and run SITL (login shell required because python modules need /usr/local/bin in the PATH!)
-call mintty -e bash --login -c "trap bash SIGINT; git clone --recursive -j8 https://github.com/PX4/Firmware.git ; cd Firmware && make posix jmavsim"
+call mintty -e bash --login -c "trap bash SIGINT; git clone --recursive -j8 https://github.com/PX4/Firmware.git ; cd Firmware && make px4_sitl jmavsim"
 popd


### PR DESCRIPTION
- ARM GCC 9 is supported by the NuttX we use since https://github.com/PX4/Firmware/pull/15139 and the Windows build got fixed with https://github.com/PX4/Firmware/pull/16040 so I'm switching to ARM GCC 9 to use the toolchain on PX4 master
- Apache Ant always deletes the old version (URL no longer available) when a new one comes out so I'm updating the version
- For the Windows toolchain I hosted an old portable JDK version for a long time now. This is not really a security issue since the version does not get installed or is accessible through the PATH. It only resides in its folder and gets used to build jmavsim. Nevertheless it makes sense to update and since I discovered openJDK is providing portable zip archives which Oracle is not I'm switching.
- Also correct the SITL build target which changed a long time ago.